### PR TITLE
feat: support bson and binary like fields

### DIFF
--- a/tap_mongodb/collection.py
+++ b/tap_mongodb/collection.py
@@ -21,6 +21,7 @@ from singer_sdk.streams.core import (
     REPLICATION_LOG_BASED,
     TypeConformanceLevel,
 )
+from .utils import _coerce_bytelikes_to_base64
 
 
 def _flatten_record(
@@ -146,6 +147,10 @@ class CollectionStream(Stream):
             else:
                 # Return the record as is
                 yield record
+
+    def post_process(self, row: dict, context: dict | None = None) -> dict:
+        """Sanitize records by converting bytelikes to base64 strings."""
+        return _coerce_bytelikes_to_base64(row)
 
     def _generate_record_messages(
         self,

--- a/tap_mongodb/utils.py
+++ b/tap_mongodb/utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from bson.binary import Binary
+
+
+def _coerce_bytelikes_to_base64(value: Any) -> Any:
+    """
+    Recursively convert bytelike values to base64-encoded strings.
+
+    Purpose:
+    - Singer SDK's JSON serialization expects JSON-safe types. Raw bytes are not
+      JSON-serializable and can cause UnicodeDecodeError when encoded as UTF-8.
+    - MongoDB documents can contain bytelike fields (e.g., bson.binary.Binary).
+      This helper ensures all such values are converted to base64 strings before
+      emission, without altering schemas downstream.
+
+    Behavior:
+    - bytes/bytearray/memoryview/`bson.binary.Binary` -> base64 ASCII string
+    - dict/list/tuple are traversed recursively
+    - all other values are returned unchanged
+    """
+
+    if isinstance(value, (bytes, bytearray, memoryview, Binary)):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    if isinstance(value, dict):
+        return {k: _coerce_bytelikes_to_base64(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_coerce_bytelikes_to_base64(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_coerce_bytelikes_to_base64(v) for v in value)
+    return value


### PR DESCRIPTION
Was previously getting unidecode errors for binary and bson fields:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xdc in position 5: invalid continuation byte
```

This PR converts byte like objects to base64